### PR TITLE
Updated set of optional parameters for Yandex Metrica integration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,6 @@ var Yandex = module.exports = integration('Yandex Metrica')
   .option('trackHash', false)
   .option('trackLinks', false)
   .option('accurateTrackBounce', false)
-  .option('params', null)
   .tag('<script src="//mc.yandex.ru/metrika/watch.js">');
 
 /**
@@ -43,7 +42,6 @@ Yandex.prototype.initialize = function() {
   var trackHash = this.options.trackHash;
   var trackLinks = this.options.trackLinks;
   var accurateTrackBounce = this.options.accurateTrackBounce;
-  var params = this.options.params;
 
   push(function() {
     window['yaCounter' + id] = new window.Ya.Metrika({
@@ -54,7 +52,6 @@ Yandex.prototype.initialize = function() {
       trackHash: trackHash,
       trackLinks: trackLinks,
       accurateTrackBounce: accurateTrackBounce,
-      params: params
     });
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,8 +29,8 @@ var Yandex = module.exports = integration('Yandex Metrica')
 /**
  * Initialize.
  *
- * http://api.yandex.com/metrika/
- * https://metrica.yandex.com/22522351?step=2#tab=code
+ * https://tech.yandex.com/metrika/
+ * http://help.yandex.com/metrica/objects/creating-object.xml
  *
  * @api public
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,14 @@ var Yandex = module.exports = integration('Yandex Metrica')
   .assumesPageview()
   .global('yandex_metrika_callbacks')
   .global('Ya')
+  .option('type', 0)
   .option('counterId', null)
   .option('clickmap', false)
   .option('webvisor', false)
+  .option('trackHash', false)
+  .option('trackLinks', false)
+  .option('accurateTrackBounce', false)
+  .option('params', null)
   .tag('<script src="//mc.yandex.ru/metrika/watch.js">');
 
 /**
@@ -32,14 +37,24 @@ var Yandex = module.exports = integration('Yandex Metrica')
 
 Yandex.prototype.initialize = function() {
   var id = this.options.counterId;
+  var type = this.options.type;
   var clickmap = this.options.clickmap;
   var webvisor = this.options.webvisor;
+  var trackHash = this.options.trackHash;
+  var trackLinks = this.options.trackLinks;
+  var accurateTrackBounce = this.options.accurateTrackBounce;
+  var params = this.options.params;
 
   push(function() {
     window['yaCounter' + id] = new window.Ya.Metrika({
       id: id,
+      type: type,
       clickmap: clickmap,
-      webvisor: webvisor
+      webvisor: webvisor,
+      trackHash: trackHash,
+      trackLinks: trackLinks,
+      accurateTrackBounce: accurateTrackBounce,
+      params: params
     });
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ Yandex.prototype.initialize = function() {
       webvisor: webvisor,
       trackHash: trackHash,
       trackLinks: trackLinks,
-      accurateTrackBounce: accurateTrackBounce,
+      accurateTrackBounce: accurateTrackBounce
     });
   });
 


### PR DESCRIPTION
Hi guys, i decided to update this integration mostly because of need to set custom parameters for Yandex Metrica, and since there was a couple of other, missing, i added them too.

You can find official documentation with description of each parameter [here](http://help.yandex.com/metrica/objects/creating-object.xml)

P.S. I intentionally left `ut` parameter aside since it's pretty easy to mess up with it and default value is not clear (empty string for `no`, but `0` is the same as `noindex` looks pretty weird to me). And `defer` parameter will probably break your integration so there is no need of that unless someone will add support for it.

By the way, your service is amazing :+1: 
